### PR TITLE
java-example improvements

### DIFF
--- a/java-example/src/main/java/com/vmware/App.java
+++ b/java-example/src/main/java/com/vmware/App.java
@@ -22,47 +22,65 @@ public class App {
 
     public static void main(String[] args) throws InterruptedException {
 
-        /*tracer must be acquired, which is responsible for creating spans and interacting with the Context*/
+        /*
+        Tracer must be acquired, which is responsible for creating spans and interacting with the
+          Context
+         */
         tracer = getTracer();
 
-        //an automated way to propagate the parent span on the current thread
+        // An automated way to propagate the parent span on the current thread
         for (int index = 0; index < 3; index++) {
-            //create a span by specifying the name of the span. The start and end time of the span is automatically set by the OpenTelemetry SDK
+            /*
+            Create a span by specifying the name of the span. The start and end time of the span
+            is automatically set by the OpenTelemetry SDK
+             */
             Span parentSpan = tracer.spanBuilder("parentSpan" + index).setNoParent().startSpan();
             logger.info("In parent method. TraceID : {}", parentSpan.getSpanContext().getTraceId());
 
-            //put the span into the current Context
             try {
+                // Put the span into the current Context
                 parentSpan.makeCurrent();
-                //annotate the span with attributes specific to the represented operation, to provide additional context
+
+                /*
+                Annotate the span with attributes specific to the represented operation, to
+                provide additional context
+                 */
                 parentSpan.setAttribute("parentIndex", index);
-                childMethod(parentSpan);
+
+                // Sleep to simulate some work being done before calling `childMethod`
+                Thread.sleep(500);
+                childMethod(parentSpan, index);
+
+                // Sleep to simulate work being done after `childMethod` returns
+                Thread.sleep(500 * index);
             } catch (Throwable throwable) {
                 parentSpan.setStatus(StatusCode.ERROR, "Exception message: " + throwable.getMessage());
                 return;
             } finally {
-                //closing the scope does not end the span, this has to be done manually
+                // Closing the scope does not end the span, this has to be done manually
                 parentSpan.end();
             }
         }
 
-        //sleep for a bit to let everything settle
+        // Sleep for a bit to let everything settle
         Thread.sleep(2000);
     }
 
-    private static void childMethod(Span parentSpan) {
-
+    private static void childMethod(Span parentSpan, int index) {
         tracer = getTracer();
 
-        //setParent(...) is not required, `Span.current()` is automatically added as the parent
+        // `setParent(...)` is not required, `Span.current()` is automatically added as the parent
         Span childSpan = tracer.spanBuilder("childSpan").setParent(Context.current().with(parentSpan))
                 .startSpan();
         logger.info("In child method. TraceID : {}", childSpan.getSpanContext().getTraceId());
         Attributes eventAttrs = Attributes.builder().put("a-key", "a-val").build();
         childSpan.addEvent("child-event", eventAttrs);
 
-        //put the span into the current Context
+        // Put the span into the current Context
         try (Scope scope = childSpan.makeCurrent()) {
+            if (index == 1) {
+                childSpan.setStatus(StatusCode.ERROR, "Errored (arbitrarily) because index=1");
+            }
             Thread.sleep(1000);
         } catch (Throwable throwable) {
             childSpan.setStatus(StatusCode.ERROR, "Something wrong with the child span");
@@ -74,10 +92,13 @@ public class App {
     private static synchronized Tracer getTracer() {
         if (tracer == null) {
 
-            //it is important to initialize your SDK as early as possible in your application's lifecycle
+            /*
+            It is important to initialize your SDK as early as possible in your application's
+            lifecycle
+             */
             OpenTelemetry openTelemetry = OTelConfig.initOpenTelemetry();
 
-            //get a tracer
+            // Get a tracer
             tracer = openTelemetry.getTracer(INSTRUMENTATION_LIBRARY_NAME, INSTRUMENTATION_VERSION);
         }
 

--- a/java-example/src/main/java/com/vmware/OTelConfig.java
+++ b/java-example/src/main/java/com/vmware/OTelConfig.java
@@ -7,7 +7,6 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
-import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
 
 import java.util.concurrent.TimeUnit;
 
@@ -15,15 +14,14 @@ import java.util.concurrent.TimeUnit;
  * @author Sumit Deo (deosu@vmware.com)
  */
 public class OTelConfig {
-    private static final String SERVICE_NAME_VALUE = "otel-otlp-java-service";
+    private static final String SERVICE_NAME_VALUE = "otel-java-svc";
     public static final String OTEL_COLLECTOR_ENDPOINT = "http://localhost:4317";
-    public static final String APP_NAME_VALUE = "otel-otlp-java-app";
+    public static final String APP_NAME_VALUE = "otel-java-app";
     public static final String SERVICE_NAME_KEY = "service.name";
     public static final String APP_NAME_KEY = "application";
 
 
-    //Adds a BatchSpanProcessor initialized with OtlpGrpcSpanExporter to the TracerSdkProvider.
-
+    // Adds a BatchSpanProcessor initialized with OtlpGrpcSpanExporter to the TracerSdkProvider.
     static OpenTelemetry initOpenTelemetry() {
         OtlpGrpcSpanExporter spanExporter = getOtlpGrpcSpanExporter();
         BatchSpanProcessor spanProcessor = getBatchSpanProcessor(spanExporter);


### PR DESCRIPTION
- Add sleeps to simulate work being done before and after the childSpan to make UI of traces more visually interesting
- Shorten application and service names so they take up less horizontal space in UI
- Add an error to childSpan if parentSpan index is 1, to make UI more visually interesting
- Clean up comments