### PR TITLE
[Don't Merge to Master] - Update the proxy examples for CSP

### DIFF
--- a/DOTNET-example/README.md
+++ b/DOTNET-example/README.md
@@ -13,12 +13,10 @@ will eventually export the trace data to our UI.
 
 * A VMware Aria Operations for Applications account (formerly known as Tanzu Observability by Wavefront) account, which gives you access to a cluster. If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
-* Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
-  ```
-  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
-  -p 4317:4317 \  
-  ```
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). 
+  <br/>**Note**: When running the Wavefront proxy:
+  * Make sure that the `WAVEFRONT_PROXY_ARGS` environment variable contains `--otlpGrpcListenerPorts 4317`.
+  * And expose the OpenTelemetry port via `-p 4317:4317`.
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).
@@ -125,12 +123,10 @@ can add additional spans manually over sections of the code.
 * An Aria Operations for Applications (formerly known as Tanzu Observability by Wavefront) account, which gives you access to a cluster. 
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
-* Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
-  ```
-  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
-  -p 4317:4317 \  
-  ```
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). 
+  <br/>**Note**: When running the Wavefront proxy:
+  * Make sure that the `WAVEFRONT_PROXY_ARGS` environment variable contains `--otlpGrpcListenerPorts 4317`.
+  * And expose the OpenTelemetry port via `-p 4317:4317`.
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).

--- a/DOTNET-example/README.md
+++ b/DOTNET-example/README.md
@@ -14,23 +14,11 @@ will eventually export the trace data to our UI.
 * A VMware Aria Operations for Applications account (formerly known as Tanzu Observability by Wavefront) account, which gives you access to a cluster. If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
 * Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* Install the Wavefront proxy on Docker    
-    ```
-    docker run -d \
-        -e WAVEFRONT_URL=https://{INSTANCE_NAME}.wavefront.com/api/ \
-        -e WAVEFRONT_TOKEN={TOKEN} \
-        -e JAVA_HEAP_USAGE=512m \
-        -e WAVEFRONT_PROXY_ARGS="--customTracingListenerPorts 30001" \
-        -p 2878:2878 \
-        -p 30001:30001 \
-        wavefronthq/proxy:latest
-    ```
-    Replace:
-    * `{INSTANCE_NAME}` with the product instance (for example, https://longboard.wavefront.com).
-    * `{TOKEN}` with the API token linked to an account with Proxy permission.
-      See [Generating and an API Token](https://docs.wavefront.com/wavefront_api.html#generating-an-api-token).
-    
-    See [Install a Proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy) to find other options for installing the proxy on your environment.
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
+  ```
+  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
+  -p 4317:4317 \  
+  ```
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).
@@ -138,18 +126,11 @@ can add additional spans manually over sections of the code.
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
 * Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* Install the Wavefront proxy on Docker.
-    ```
-    docker run -d \
-        -e WAVEFRONT_URL=https://{INSTANCE_NAME}.wavefront.com/api/ \
-        -e WAVEFRONT_TOKEN={TOKEN} \
-        -e JAVA_HEAP_USAGE=512m \
-        -e WAVEFRONT_PROXY_ARGS="--customTracingListenerPorts 30001" \
-        -p 2878:2878 \
-        -p 30001:30001 \
-        wavefronthq/proxy:latest
-    ```
-    See [Install a Proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy) to find other options for installing the proxy on your environment.
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
+  ```
+  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
+  -p 4317:4317 \  
+  ```
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ If you use OpenTelemetry, you can configure the application to send traces or me
 
 ## Configure the Wavefront Proxy
 
-**Note**: Starting June 26, 2023, VMware Aria Operations for Applications is a service on the VMware Cloud services platform (CSP). With this update, the Wavefront proxy supports authentication to Operations for Applications with a VMware Cloud services API token or OAuth app. For more information, see [Proxy Authentication Types](proxies_installing.html#proxy-authentication-types).
-
 1. [Install the Wavefront proxy](https://docs.wavefront.com/proxies_installing.html).
 1. Configure the Wavefront proxy to send OpenTelemetry data to our service. See the [Wavefront proxy settings for OpenTelemetry](https://docs.wavefront.com/proxies_configuring.html#opentelemetry-proxy-properties).
   * **Trace data**: Port 4317 (recommended) with `otlpGrpcListenerPorts` **or** port 4318 (recommended) with `otlpHttpListenerPorts`.
@@ -15,52 +13,6 @@ If you use OpenTelemetry, you can configure the application to send traces or me
     * Port 4317 (recommended) with `otlpGrpcListenerPorts` **or** port 4318 (recommended) with `otlpHttpListenerPorts`.
     * To receive the OpenTelemetry resource attributes that your application sends for metrics data, set `otlpResourceAttrsOnMetricsIncluded` to `true`.
       <br/>**Note**: Be aware that setting this to `true` increases the chance of metrics exceeding the [annotations count limit on your cluster](https://docs.wavefront.com/wavefront_limits.html#default-customer-specific-limits), causing the metrics to be dropped by the Wavefront proxy.
-
-### Examples
-
-The following examples run the Wavefront Proxy on Docker and send trace data to our service.
-
-* Applications using OAuth: 
-  <br/>**Note**: The proxy requires a VMware Cloud services API token with the **Proxies** service role.
-
-  ```
-  docker run -d \
-  -e WAVEFRONT_URL=https://<INSTANCE>.wavefront.com/api/ \
-  -e CSP_APP_ID <Your_CSP_Application_ID> \
-  -e CSP_APP_SECRET <Your_CSP_Application_secret_Key> \
-  -e CSP_ORG_ID <Your_CSP_Organization_ID> \
-  -e JAVA_HEAP_USAGE=512m \
-  - otlpGrpcListenerPorts 4317
-  -p 2878:2878 \
-  -p 4317:4317 \
-  wavefronthq/proxy:latest
-  ```
-* Applications using the CSP API token:
-  <br/>**Note**: The proxy requires a VMware Cloud services API token with the **Proxies** service role.
-
-  ```
-  docker run -d \
-  -e WAVEFRONT_URL=https://<INSTANCE>.wavefront.com/api/ \
-  -e CSP_API_TOKEN=<Your_CSP_API_Token> \
-  -e JAVA_HEAP_USAGE=512m \
-  - otlpGrpcListenerPorts 4317
-  -p 2878:2878 \
-  -p 4317:4317 \
-  wavefronthq/proxy:latest
-  ```
-
-* If you are not using CSP (original Operations for Applications subscriptions), the Wavefront proxy 13.0 still supports authentication with Operations for Applications tokens.
-
-  ```
-  docker run -d \
-  -e WAVEFRONT_URL=https://<INSTANCE>.wavefront.com/api/ \
-  -e WAVEFRONT_TOKEN=<TOKEN> \
-  -e JAVA_HEAP_USAGE=512M \
-  - otlpGrpcListenerPorts 4317 \
-  -p 2878:2878 \
-  -p 4317:4317 \
-  wavefronthq/proxy:latest
-  ```
 
 ## Send and View Data
 

--- a/README.md
+++ b/README.md
@@ -4,34 +4,67 @@ If you use OpenTelemetry, you can configure the application to send traces or me
 
 <img src="images/opentelemetry_proxy_tracing.png" alt="A data flow diagram that shows how the data flows from your application to the proxy, and then to our service" style="width:750px;"/>
 
-## Send Data
+## Configure the Wavefront Proxy
 
-Follow these steps to send traces or metrics to our service:
+**Note**: Starting June 26, 2023, VMware Aria Operations for Applications is a service on the VMware Cloud services platform (CSP) and the Wavefront proxy supports authentication to Operations for Applications with a VMware Cloud services API token or OAuth app. For more information, see [Proxy Authentication Types](proxies_installing.html#proxy-authentication-types).
 
 1. [Install the Wavefront proxy](https://docs.wavefront.com/proxies_installing.html).
 1. Configure the Wavefront proxy to send OpenTelemetry data to our service. See the [Wavefront proxy settings for OpenTelemetry](https://docs.wavefront.com/proxies_configuring.html#opentelemetry-proxy-properties).
-    * **Trace data**: Port 4317 (recommended) with `otlpGrpcListenerPorts` **or** port 4318 (recommended) with `otlpHttpListenerPorts`.
-    * **Metrics data**: 
-      * Port 4317 (recommended) with `otlpGrpcListenerPorts` **or** port 4318 (recommended) with `otlpHttpListenerPorts`.
-      * To receive the OpenTelemetry resource attributes that your application sends for metrics data, set `otlpResourceAttrsOnMetricsIncluded` to `true`.
-        <br/>**Note**: Be aware that setting this to `true` increases the chance of metrics exceeding the [annotations count limit on your cluster](https://docs.wavefront.com/wavefront_limits.html#default-customer-specific-limits), causing the metrics to be dropped by the Wavefront proxy.
-      
-      For example, the command to start the proxy on Docker:
-      ```
-      docker run -d \
-      -e WAVEFRONT_URL=https://<INSTANCE>.wavefront.com/api/ \
-      -e WAVEFRONT_TOKEN=<TOKEN> \
-      -e JAVA_HEAP_USAGE=512M \
-      -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
-      -p 2878:2878 \
-      -p 4317:4317 \
-      wavefronthq/proxy:latest
-      ```
-      <br/>For example, on Linux, Mac, and Windows:
-        * Open the [`wavefront.conf`](https://docs.wavefront.com/proxies_configuring.html#proxy-file-paths) file.
-        * Add the `otlpGrpcListenerPorts=4317` configuration.
-        * Save the file.
+  * **Trace data**: Port 4317 (recommended) with `otlpGrpcListenerPorts` **or** port 4318 (recommended) with `otlpHttpListenerPorts`.
+  * **Metrics data**: 
+    * Port 4317 (recommended) with `otlpGrpcListenerPorts` **or** port 4318 (recommended) with `otlpHttpListenerPorts`.
+    * To receive the OpenTelemetry resource attributes that your application sends for metrics data, set `otlpResourceAttrsOnMetricsIncluded` to `true`.
+      <br/>**Note**: Be aware that setting this to `true` increases the chance of metrics exceeding the [annotations count limit on your cluster](https://docs.wavefront.com/wavefront_limits.html#default-customer-specific-limits), causing the metrics to be dropped by the Wavefront proxy.
 
+### Examples
+
+The following examples run the Wavefront Proxy on Docker and sends trace data to our service.
+
+* Applications using OAuth: 
+  **Note**: The proxy requires a VMware Cloud services API token with the **Proxies** service role.
+
+  ```
+  docker run -d \
+  -e WAVEFRONT_URL=https://<INSTANCE>.wavefront.com/api/ \
+  -e CSP_APP_ID <Your_CSP_Application_ID> \
+  -e CSP_APP_SECRET <Your_CSP_Application_secret_Key> \
+  -e CSP_ORG_ID <Your_CSP_Organization_ID> \
+  -e JAVA_HEAP_USAGE=512m \
+  - otlpGrpcListenerPorts 4317
+  -p 2878:2878 \
+  -p 4317:4317 \
+  wavefronthq/proxy:latest
+  ```
+* Applications using the CSP API token:
+  **Note**: The proxy requires a VMware Cloud services API token with the **Proxies** service role.
+
+  ```
+  docker run -d \
+  -e WAVEFRONT_URL=https://<INSTANCE>.wavefront.com/api/ \
+  -e CSP_API_TOKEN=<Your_CSP_API_Token> \
+  -e JAVA_HEAP_USAGE=512m \
+  - otlpGrpcListenerPorts 4317
+  -p 2878:2878 \
+  -p 4317:4317 \
+  wavefronthq/proxy:latest
+  ```
+
+* If you are not using CSP (original Operations for Applications subscriptions), the Wavefront proxy 13.0 still supports authentication with Operations for Applications tokens.
+
+  ```
+  docker run -d \
+  -e WAVEFRONT_URL=https://<INSTANCE>.wavefront.com/api/ \
+  -e WAVEFRONT_TOKEN=<TOKEN> \
+  -e JAVA_HEAP_USAGE=512M \
+  - otlpGrpcListenerPorts 4317 \
+  -p 2878:2878 \
+  -p 4317:4317 \
+  wavefronthq/proxy:latest
+  ```
+
+## Send and View Data
+
+Follow these steps to send traces or metrics to our service:
 
 1. Configure your application to send trace data to the Wavefront proxy. 
     <br/>By default, OpenTelemetry SDKs send data over gRPC to `http://localhost:4317`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you use OpenTelemetry, you can configure the application to send traces or me
 
 ## Configure the Wavefront Proxy
 
-**Note**: Starting June 26, 2023, VMware Aria Operations for Applications is a service on the VMware Cloud services platform (CSP) and the Wavefront proxy supports authentication to Operations for Applications with a VMware Cloud services API token or OAuth app. For more information, see [Proxy Authentication Types](proxies_installing.html#proxy-authentication-types).
+**Note**: Starting June 26, 2023, VMware Aria Operations for Applications is a service on the VMware Cloud services platform (CSP). With this update, the Wavefront proxy supports authentication to Operations for Applications with a VMware Cloud services API token or OAuth app. For more information, see [Proxy Authentication Types](proxies_installing.html#proxy-authentication-types).
 
 1. [Install the Wavefront proxy](https://docs.wavefront.com/proxies_installing.html).
 1. Configure the Wavefront proxy to send OpenTelemetry data to our service. See the [Wavefront proxy settings for OpenTelemetry](https://docs.wavefront.com/proxies_configuring.html#opentelemetry-proxy-properties).
@@ -18,10 +18,10 @@ If you use OpenTelemetry, you can configure the application to send traces or me
 
 ### Examples
 
-The following examples run the Wavefront Proxy on Docker and sends trace data to our service.
+The following examples run the Wavefront Proxy on Docker and send trace data to our service.
 
 * Applications using OAuth: 
-  **Note**: The proxy requires a VMware Cloud services API token with the **Proxies** service role.
+  <br/>**Note**: The proxy requires a VMware Cloud services API token with the **Proxies** service role.
 
   ```
   docker run -d \
@@ -36,7 +36,7 @@ The following examples run the Wavefront Proxy on Docker and sends trace data to
   wavefronthq/proxy:latest
   ```
 * Applications using the CSP API token:
-  **Note**: The proxy requires a VMware Cloud services API token with the **Proxies** service role.
+  <br/>**Note**: The proxy requires a VMware Cloud services API token with the **Proxies** service role.
 
   ```
   docker run -d \

--- a/go-example/auto-instrumentation/README.md
+++ b/go-example/auto-instrumentation/README.md
@@ -11,23 +11,11 @@ this [working example](https://github.com/wavefrontHQ/opentelemetry-examples/blo
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
 * Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* Install the Wavefront proxy on Docker.
-    ```
-    docker run -d \
-        -e WAVEFRONT_URL=https://{INSTANCE_NAME}.wavefront.com/api/ \
-        -e WAVEFRONT_TOKEN={TOKEN} \
-        -e JAVA_HEAP_USAGE=512m \
-        -e WAVEFRONT_PROXY_ARGS="--customTracingListenerPorts 30001" \
-        -p 2878:2878 \
-        -p 30001:30001 \
-        wavefronthq/proxy:latest
-    ```
-    Replace:
-    * `{INSTANCE_NAME}` with the product instance (for example, https://longboard.wavefront.com).
-    * `{TOKEN}` with the API token linked to an account with Proxy permission.
-      See [Generating and an API Token](https://docs.wavefront.com/wavefront_api.html#generating-an-api-token).
-    
-    See [Install a Proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy) to find other options for installing the proxy on your environment.
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
+  ```
+  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
+  -p 4317:4317 \  
+  ```
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).
@@ -114,23 +102,11 @@ this [working example](https://github.com/wavefrontHQ/opentelemetry-examples/blo
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
 * Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* Install the Wavefront proxy on Docker.
-    ```
-    docker run -d \
-        -e WAVEFRONT_URL=https://{INSTANCE_NAME}.wavefront.com/api/ \
-        -e WAVEFRONT_TOKEN={TOKEN} \
-        -e JAVA_HEAP_USAGE=512m \
-        -e WAVEFRONT_PROXY_ARGS="--customTracingListenerPorts 30001" \
-        -p 2878:2878 \
-        -p 30001:30001 \
-        wavefronthq/proxy:latest
-    ```
-    Replace:
-    * `{INSTANCE_NAME}` with the product instance (for example, https://longboard.wavefront.com).
-    * `{TOKEN}` with the API token linked to an account with Proxy permission.
-      See [Generating and an API Token](https://docs.wavefront.com/wavefront_api.html#generating-an-api-token).
-    
-    See [Install a Proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy) to find other options for installing the proxy on your environment.
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
+  ```
+  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
+  -p 4317:4317 \  
+  ```
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).

--- a/go-example/auto-instrumentation/README.md
+++ b/go-example/auto-instrumentation/README.md
@@ -10,12 +10,10 @@ this [working example](https://github.com/wavefrontHQ/opentelemetry-examples/blo
 * A VMware Aria Operations for Applications account (formerly known as Tanzu Observability by Wavefront) account, which gives you access to a cluster. 
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
-* Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
-  ```
-  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
-  -p 4317:4317 \  
-  ```
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy).
+  <br/>**Note**: When running the Wavefront proxy:
+  * Make sure that the `WAVEFRONT_PROXY_ARGS` environment variable contains `--otlpGrpcListenerPorts 4317`.
+  * And expose the OpenTelemetry port via `-p 4317:4317`.
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).
@@ -101,12 +99,10 @@ this [working example](https://github.com/wavefrontHQ/opentelemetry-examples/blo
 * A Aria Operations for Applications account, which gives you access to a cluster. 
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
-* Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
-  ```
-  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
-  -p 4317:4317 \  
-  ```
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy).
+  <br/>**Note**: When running the Wavefront proxy:
+  * Make sure that the `WAVEFRONT_PROXY_ARGS` environment variable contains `--otlpGrpcListenerPorts 4317`.
+  * And expose the OpenTelemetry port via `-p 4317:4317`.
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).

--- a/go-example/manual-instrumentation/README.md
+++ b/go-example/manual-instrumentation/README.md
@@ -12,23 +12,11 @@ this [working example](https://github.com/wavefrontHQ/opentelemetry-examples/blo
     If you don’t have a cluster, [sign up for a free trial](https://tanzu.vmware.com/observability-trial).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
 * Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* Install the Wavefront proxy on Docker.
-    ```
-    docker run -d \
-        -e WAVEFRONT_URL=https://{INSTANCE_NAME}.wavefront.com/api/ \
-        -e WAVEFRONT_TOKEN={TOKEN} \
-        -e JAVA_HEAP_USAGE=512m \
-        -e WAVEFRONT_PROXY_ARGS="--customTracingListenerPorts 30001" \
-        -p 2878:2878 \
-        -p 30001:30001 \
-        wavefronthq/proxy:latest
-    ```
-    Replace:
-    * `{INSTANCE_NAME}` with the Tanzu Observability instance (for example, https://longboard.wavefront.com).
-    * `{TOKEN}` with a Tanzu Observability API token linked to an account with Proxy permission.
-      See [Generating and an API Token](https://docs.wavefront.com/wavefront_api.html#generating-an-api-token).
-    
-    See [Install a Proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy) to find other options for installing the proxy on your environment.
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
+  ```
+  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
+  -p 4317:4317 \  
+  ```
     
 * Set up an OpenTelemetry Collector for Tanzu Observability:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).

--- a/go-example/manual-instrumentation/README.md
+++ b/go-example/manual-instrumentation/README.md
@@ -11,12 +11,10 @@ this [working example](https://github.com/wavefrontHQ/opentelemetry-examples/blo
 * A Tanzu Observability by Wavefront account, which gives you access to a cluster. 
     If you don’t have a cluster, [sign up for a free trial](https://tanzu.vmware.com/observability-trial).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
-* Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
-  ```
-  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
-  -p 4317:4317 \  
-  ```
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy).
+  <br/>**Note**: When running the Wavefront proxy:
+  * Make sure that the `WAVEFRONT_PROXY_ARGS` environment variable contains `--otlpGrpcListenerPorts 4317`.
+  * And expose the OpenTelemetry port via `-p 4317:4317`.
     
 * Set up an OpenTelemetry Collector for Tanzu Observability:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).

--- a/go-example/metrics/metric_example/README.md
+++ b/go-example/metrics/metric_example/README.md
@@ -7,13 +7,10 @@ This section shows a working example of a Go application that send metrics to th
 * A Tanzu Observability by Wavefront account, which gives you access to a cluster. 
     If you don’t have a cluster, [sign up for a free trial](https://tanzu.vmware.com/observability-trial).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
-* Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
-  ```
-  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317 --otlpResourceAttrsOnMetricsIncluded true" \
-  -p 4317:4317 \  
-  ```
-    
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy).
+    <br/>**Note**: When running the Wavefront proxy:
+    * Make sure that the `WAVEFRONT_PROXY_ARGS` environment variable contains `--otlpGrpcListenerPorts 4317`.
+    * And expose the OpenTelemetry port via `-p 4317:4317`.
 * Set up an OpenTelemetry Collector for Tanzu Observability:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).
     1. In the same directory, create a file named `otel_collector_config.yaml`.

--- a/go-example/metrics/metric_example/README.md
+++ b/go-example/metrics/metric_example/README.md
@@ -8,23 +8,11 @@ This section shows a working example of a Go application that send metrics to th
     If you don’t have a cluster, [sign up for a free trial](https://tanzu.vmware.com/observability-trial).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
 * Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* Install the Wavefront proxy on Docker.
-    ```
-    docker run -d \
-        -e WAVEFRONT_URL=https://{INSTANCE_NAME}.wavefront.com/api/ \
-        -e WAVEFRONT_TOKEN={TOKEN} \
-        -e JAVA_HEAP_USAGE=512m \
-        -e WAVEFRONT_PROXY_ARGS="--customTracingListenerPorts 30001" \
-        -p 2878:2878 \
-        -p 30001:30001 \
-        wavefronthq/proxy:latest
-    ```
-    Replace:
-    * `{INSTANCE_NAME}` with the Tanzu Observability instance (for example, https://longboard.wavefront.com).
-    * `{TOKEN}` with a Tanzu Observability API token linked to an account with Proxy permission.
-      See [Generating and an API Token](https://docs.wavefront.com/wavefront_api.html#generating-an-api-token).
-    
-    See [Install a Proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy) to find other options for installing the proxy on your environment.
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
+  ```
+  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317 --otlpResourceAttrsOnMetricsIncluded true" \
+  -p 4317:4317 \  
+  ```
     
 * Set up an OpenTelemetry Collector for Tanzu Observability:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -5,17 +5,17 @@ This guide shows you how to auto instrument your Java application using the Open
 ## Prerequisites
 
 * A VMware Aria Operations for Applications (formerly known as Tanzu Observability by Wavefront) account to visualize and monitor your application health. If you don’t have one already, you can sign up on [our website](https://www.vmware.com/products/aria-operations-for-applications.html). 
-* Docker to run the Wavefront proxy. 
 * Java 11 or later.
 * Maven
 
 ## Install the Wavefront Proxy
 
-[Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
-```
--e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
--p 4317:4317 \  
-```
+[Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy).
+
+**Note**: When running the Wavefront proxy:
+* Make sure that the `WAVEFRONT_PROXY_ARGS` environment variable contains `--otlpGrpcListenerPorts 4317`.
+* and expose the OpenTelemetry port via `-p 4317:4317`.
+
 ## Run the Auto-Instrumented Application
 
 For instrumentation, you use the Java agent provided by OpenTelemetry, which can be attached to any Java application. This agent dynamically injects bytecode to collect telemetry data, and developers can avoid manual instrumentation. 

--- a/java-example/README.md
+++ b/java-example/README.md
@@ -9,38 +9,13 @@ This guide shows you how to auto instrument your Java application using the Open
 * Java 11 or later.
 * Maven
 
-
 ## Install the Wavefront Proxy
 
-Follow these steps to install the Wavefront proxy using Docker. See [Install a Proxy](https://docs.wavefront.com/proxies_installing.html#install-a-proxy) to find other options for installing the proxy in your environment.
-
-1. Make sure you have **Proxies** permission.
-    1. Click the gear icon on the toolbar and select your username.
-    1. On the **Groups, Roles & Permissions** tab, verify that the **Proxies** check box is selected.
-    1. If you don’t see the check box next to **Proxies** selected, ask a user with the **Accounts** permission to grant you with the **Proxies** permission.
-
-1. [Generate an API Token](https://docs.wavefront.com/wavefront_api.html#generating-an-api-token).
-1. Run the following command to install the proxy:
-    ```
-    docker run -d \
-        -e WAVEFRONT_URL=https://{CLUSTER}.wavefront.com/api/ \
-        -e WAVEFRONT_TOKEN={TOKEN} \
-        -e JAVA_HEAP_USAGE=512m \
-        -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
-        -p 2878:2878 \
-        -p 4317:4317 \
-        wavefronthq/proxy:latest
-    ```
-    You need to:
-    * Replace `{CLUSTER}` with the name of your cluster.
-    * Replace `{TOKEN}` with the API token that you generated. 
-1. Confirm that the proxy is running.
-    ```
-    docker ps
-    ```
-
-    If `docker ps` does not list the Wavefront proxy, it means that the Wavefront proxy stopped running. If this happens, use `docker logs <container ID>` to view the logs and find the issue. The `docker` command you ran in step 3 prints out the container ID.
-
+[Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
+```
+-e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
+-p 4317:4317 \  
+```
 ## Run the Auto-Instrumented Application
 
 For instrumentation, you use the Java agent provided by OpenTelemetry, which can be attached to any Java application. This agent dynamically injects bytecode to collect telemetry data, and developers can avoid manual instrumentation. 

--- a/java-metric-example/README.md
+++ b/java-metric-example/README.md
@@ -11,12 +11,10 @@ should not be used in the production setting. Follow this [PR](https://github.co
 * A VMware Aria Operations for Applications (formerly known as Tanzu Observability by Wavefront) account, which gives you access to a cluster. 
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
-* Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
-  ```
-  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317 --otlpResourceAttrsOnMetricsIncluded true" \
-  -p 4317:4317 \  
-  ```
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy).
+  <br/>**Note**: When running the Wavefront proxy:
+  * Make sure that the `WAVEFRONT_PROXY_ARGS` environment variable contains `--otlpGrpcListenerPorts 4317`.
+  * And expose the OpenTelemetry port via `-p 4317:4317`.
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).
     1. In the same directory, create a file named `otel_collector_config.yaml`.

--- a/java-metric-example/README.md
+++ b/java-metric-example/README.md
@@ -12,24 +12,11 @@ should not be used in the production setting. Follow this [PR](https://github.co
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
 * Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* Install the Wavefront proxy on Docker.
-    ```
-    docker run -d \
-        -e WAVEFRONT_URL=https://{INSTANCE_NAME}.wavefront.com/api/ \
-        -e WAVEFRONT_TOKEN={TOKEN} \
-        -e JAVA_HEAP_USAGE=512m \
-        -e WAVEFRONT_PROXY_ARGS="--customTracingListenerPorts 30001" \
-        -p 2878:2878 \
-        -p 30001:30001 \
-        wavefronthq/proxy:latest
-    ```
-    Replace:
-    * `{INSTANCE_NAME}` with the product instance (for example, https://longboard.wavefront.com).
-    * `{TOKEN}` with the API token linked to an account with Proxy permission.
-      See [Generating and an API Token](https://docs.wavefront.com/wavefront_api.html#generating-an-api-token).
-    
-    See [Install a Proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy) to find other options for installing the proxy on your environment.
-    
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
+  ```
+  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317 --otlpResourceAttrsOnMetricsIncluded true" \
+  -p 4317:4317 \  
+  ```
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).
     1. In the same directory, create a file named `otel_collector_config.yaml`.

--- a/python-example/README.md
+++ b/python-example/README.md
@@ -9,12 +9,10 @@ This section shows a working example of a Python application auto-instrumented w
 * A VMware Aria Operations for Applications (formerly known as Tanzu Observability by Wavefront) account, which gives you access to a cluster. 
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
-* Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
-  ```
-  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
-  -p 4317:4317 \  
-  ```
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy).
+  <br/>**Note**: When running the Wavefront proxy:
+  * Make sure that the `WAVEFRONT_PROXY_ARGS` environment variable contains `--otlpGrpcListenerPorts 4317`.
+  * And expose the OpenTelemetry port via `-p 4317:4317`.
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).
@@ -128,12 +126,10 @@ manually-instrumented with OpenTelemetry.
 * An Aria Operations for Applications account, which gives you access to a cluster. 
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
-* Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
-  ```
-  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
-  -p 4317:4317 \  
-  ```
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy).
+  <br/>**Note**: When running the Wavefront proxy:
+  * Make sure that the `WAVEFRONT_PROXY_ARGS` environment variable contains `--otlpGrpcListenerPorts 4317`.
+  * And expose the OpenTelemetry port via `-p 4317:4317`.
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).

--- a/python-example/README.md
+++ b/python-example/README.md
@@ -10,23 +10,11 @@ This section shows a working example of a Python application auto-instrumented w
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
 * Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* Install the Wavefront proxy on Docker.
-    ```
-    docker run -d \
-        -e WAVEFRONT_URL=https://{INSTANCE_NAME}.wavefront.com/api/ \
-        -e WAVEFRONT_TOKEN={TOKEN} \
-        -e JAVA_HEAP_USAGE=512m \
-        -e WAVEFRONT_PROXY_ARGS="--customTracingListenerPorts 30001" \
-        -p 2878:2878 \
-        -p 30001:30001 \
-        wavefronthq/proxy:latest
-    ```
-    Replace:
-    * `{INSTANCE_NAME}` with the product instance (for example, https://longboard.wavefront.com).
-    * `{TOKEN}` with an API token linked to an account with Proxy permission.
-      See [Generating and an API Token](https://docs.wavefront.com/wavefront_api.html#generating-an-api-token).
-    
-    See [Install a Proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy) to find other options for installing the proxy on your environment.
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
+  ```
+  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
+  -p 4317:4317 \  
+  ```
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).
@@ -141,23 +129,11 @@ manually-instrumented with OpenTelemetry.
     If you don’t have a cluster, [sign up for a free trial](https://www.vmware.com/products/aria-operations-for-applications.html).
 * Clone the [OpenTelemetry Examples](https://github.com/wavefrontHQ/opentelemetry-examples) repository.
 * Install the Docker platform. You’ll run the Wavefront proxy on Docker for this tutorial.
-* Install the Wavefront proxy on Docker.
-    ```
-    docker run -d \
-        -e WAVEFRONT_URL=https://{INSTANCE_NAME}.wavefront.com/api/ \
-        -e WAVEFRONT_TOKEN={TOKEN} \
-        -e JAVA_HEAP_USAGE=512m \
-        -e WAVEFRONT_PROXY_ARGS="--customTracingListenerPorts 30001" \
-        -p 2878:2878 \
-        -p 30001:30001 \
-        wavefronthq/proxy:latest
-    ```
-    Replace:
-    * `{INSTANCE_NAME}` with the product instance (for example, https://longboard.wavefront.com).
-    * `{TOKEN}` with an API token linked to an account with **Proxy** permission.
-      See [Generating and an API Token](https://docs.wavefront.com/wavefront_api.html#generating-an-api-token).
-    
-    See [Install a Proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy) to find other options for installing the proxy on your environment.
+* [Install the Wavefront proxy](http://docs.wavefront.com/proxies_installing.html#install-a-proxy). You need to add the following configurations to the default proxy installation configurations.
+  ```
+  -e WAVEFRONT_PROXY_ARGS="--otlpGrpcListenerPorts 4317" \
+  -p 4317:4317 \  
+  ```
     
 * Set up an OpenTelemetry Collector:
     1. Download the `otelcol-contrib` binary from the latest release of the [OpenTelemetry Collector project](https://github.com/open-telemetry/opentelemetry-collector-releases/releases).


### PR DESCRIPTION
The way we authenticate users change with CSP. This PR update the example on how to configure the proxy.